### PR TITLE
Fixed typo in relative path for ES6 d.ts file

### DIFF
--- a/firefox/data/metrics-integration/main.ts
+++ b/firefox/data/metrics-integration/main.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../../node_modules/typescript/bin/lib.es6.d.ts" />
+/// <reference path="../../../node_modules/typescript/lib/lib.es6.d.ts" />
 /// <reference path="../../defs/ES6.d.ts" />
 /// <reference path="../../defs/react-0.11.d.ts" />
 /// <reference path="../../defs/TwitterAPI.d.ts" />


### PR DESCRIPTION
The reference pointed to /bin/ where the file wasn't located. Consequently, by doing `npm run compile` many errors about ES6 showed up.