### PR TITLE
Adding a d.ts file for Twitter Assistant specific extensions and fixing path typo

### DIFF
--- a/firefox/data/metrics-integration/main.ts
+++ b/firefox/data/metrics-integration/main.ts
@@ -1,8 +1,9 @@
-/// <reference path="../../../node_modules/typescript/bin/lib.es6.d.ts" />
+/// <reference path="../../../node_modules/typescript/lib/lib.es6.d.ts" />
 /// <reference path="../../defs/ES6.d.ts" />
 /// <reference path="../../defs/react-0.11.d.ts" />
 /// <reference path="../../defs/TwitterAPI.d.ts" />
 /// <reference path="../../defs/jetpack/jetpack-port.d.ts" />
+/// <reference path="../../defs/TA-extensions.d.ts" />
 
 // declare var React : React.Exports;
 'use strict';

--- a/firefox/defs/TA-extensions.d.ts
+++ b/firefox/defs/TA-extensions.d.ts
@@ -1,0 +1,5 @@
+declare module React {
+    interface DomAttributes {
+        "data-value"?: any;
+    }
+}


### PR DESCRIPTION
Extending React type definition to declare data-value property. Thus there is no more compile erros + it allows for future "Twitter Assistant" extensions if needed.

The commit also includes a typofix for the `firefox/data/metrics-integration/main.ts` file (a path was incorrect).

