### PR TITLE
Upped version for tsify to fix build error https://github.com/DavidBruant/Twitter-Assistant/issues/110

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "browserify": "^11.0.1",
     "jpm": "^1.0.1",
     "natural": "^0.2.1",
-    "tsify": "^0.11.9",
+    "tsify": "^0.12.0",
     "typescript": "^1.5.3"
   }
 }


### PR DESCRIPTION
tsify versions under 0.12.x were unable to compile TypeScript definitions using type predicate. This caused an error during `npm run build`. Type predicates were added in TypeScript 1.6.2. Regarding "semver", 1.6.2. is ^1.5.3 (TypeScript) but 0.12.0 isn't ^0.11.9 :/

As far as I'm aware, upgrading tsify doesn't do any harm. Please revert if so.